### PR TITLE
fix: 修复字段显示去尾零时非数字文本变为 NaN --Bug=161231899

### DIFF
--- a/packages/grafana-data/src/field/displayProcessor.ts
+++ b/packages/grafana-data/src/field/displayProcessor.ts
@@ -47,7 +47,7 @@ export function getDisplayProcessor(options?: DisplayProcessorOptions): DisplayP
   const { palette } = options.theme.visualization;
 
   let unit = config.unit;
-  let hasDateUnit = unit && (timeFormats[unit] || unit.startsWith('time:'));
+  let hasDateUnit = Boolean(unit && (timeFormats[unit] || unit.startsWith('time:')));
   let showMs = false;
 
   if (field.type === FieldType.time && !hasDateUnit) {
@@ -150,7 +150,10 @@ export function getDisplayProcessor(options?: DisplayProcessorOptions): DisplayP
           // this is needed because we may have determined the minimum determined `adjacentDecimals` for y tick increments based on
           // e.g. 'seconds' field unit (0.15s, 0.20s, 0.25s), but then formatFunc decided to return milli or nanos (150, 200, 250)
           // so we end up with excess precision: 150.00, 200.00, 250.00
-          v.text = +v.text + '';
+          const asNum = +v.text;
+          if (!Number.isNaN(asNum)) {
+            v.text = asNum + '';
+          }
         } else {
           v = formatFunc(numeric, config.decimals, null, options.timeZone, showMs);
         }


### PR DESCRIPTION
## 背景
TAPD: 【Grafana】字段显示处理器去尾零时非数字文本显示为 NaN
ID: 1010158081161231899

## 改动
- packages/grafana-data/src/field/displayProcessor.ts: `hasDateUnit` 用 Boolean 归一化
- packages/grafana-data/src/field/displayProcessor.ts: 去尾零时仅在可转为数字时写回，避免显示 NaN

## 影响面
- 影响数值字段自动精度/去尾零展示；不改变业务查询逻辑

## 测试
- [ ] 非数字格式化文本不再显示为 NaN
- [ ] 可数字文本去尾零行为正常（如 60.00 → 60）
- [ ] 时间单位字段展示无回归

Made with [Cursor](https://cursor.com)